### PR TITLE
Add OAuth redirect URL scheme for iOS

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -28,19 +28,25 @@
 	<string>1.0.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
-	<key>CFBundleURLTypes</key>
-	<array>
-		<dict>
-			<key>CFBundleTypeRole</key>
-			<string>Editor</string>
-			<key>CFBundleURLSchemes</key>
-			<array>
-				<string>com.googleusercontent.apps.277362543199-4d1b88js3fgl8v0opasaf5fndv3gvd69</string>
-			</array>
-		</dict>
-	</array>
-	<key>CFBundleVersion</key>
-	<string>$(FLUTTER_BUILD_NUMBER)</string>
+        <key>CFBundleURLTypes</key>
+        <array>
+                <dict>
+                        <key>CFBundleTypeRole</key>
+                        <string>Editor</string>
+                        <key>CFBundleURLSchemes</key>
+                        <array>
+                                <string>com.googleusercontent.apps.277362543199-4d1b88js3fgl8v0opasaf5fndv3gvd69</string>
+                        </array>
+                </dict>
+                <dict>
+                        <key>CFBundleURLSchemes</key>
+                        <array>
+                                <string>ybpohdpizkbysfrvygxx</string>
+                        </array>
+                </dict>
+        </array>
+        <key>CFBundleVersion</key>
+        <string>$(FLUTTER_BUILD_NUMBER)</string>
 	<key>GIDClientID</key>
 	<string>277362543199-4d1b88js3fgl8v0opasaf5fndv3gvd69.apps.googleusercontent.com</string>
 	<key>LSRequiresIPhoneOS</key>


### PR DESCRIPTION
## Summary
- add URL scheme `ybpohdpizkbysfrvygxx` to iOS Info.plist so OAuth redirects back to app

## Testing
- `flutter test` *(fails: command not found)*
- `flutter build ios` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68ae6cf42ca4832b94208fe7e933f531