### PR TITLE
Handle incoming URLs via SupabaseFlutter on iOS

### DIFF
--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -1,5 +1,6 @@
 import Flutter
 import UIKit
+import supabase_flutter
 
 @main
 @objc class AppDelegate: FlutterAppDelegate {
@@ -9,5 +10,16 @@ import UIKit
   ) -> Bool {
     GeneratedPluginRegistrant.register(with: self)
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+  }
+
+  override func application(
+    _ app: UIApplication,
+    open url: URL,
+    options: [UIApplication.OpenURLOptionsKey: Any] = [:]
+  ) -> Bool {
+    if SupabaseFlutterPlugin.handle(url: url) {
+      return true
+    }
+    return super.application(app, open: url, options: options)
   }
 }


### PR DESCRIPTION
## Summary
- handle incoming URLs via SupabaseFlutterPlugin in iOS AppDelegate

## Testing
- `flutter test` *(fails: command not found: flutter)*
- `apt-get update` *(fails: repository InRelease is not signed; 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68ae6cf513fc832bb8a69fc77af21673