### PR TITLE
Handle missing user profile during login

### DIFF
--- a/lib/data/repository/auth/auth_repository.dart
+++ b/lib/data/repository/auth/auth_repository.dart
@@ -249,7 +249,10 @@ class AuthRepository extends AuthRepositoryInterface {
       
       // Fetch user data from Supabase user_profiles table
       final user = await findUserById(userId);
-      
+      if (user == null) {
+        throw BaseExceptions('User profile not found');
+      }
+
       return LoginResponse(userId, user);
     } on supabase.AuthException catch (e) {
       throw BaseExceptions(e.message);

--- a/lib/domain/usecases/auth/login_usecase.dart
+++ b/lib/domain/usecases/auth/login_usecase.dart
@@ -9,6 +9,7 @@ import '../../../core/usecase/usecase.dart';
 import '../../../data/model/user_dto.dart';
 import '../../../data/repository/auth/auth_repository.dart';
 import '../../../ui/modules/authentication/bloc/authentication_state.dart';
+import '../../../exception/app_exceptions.dart';
 
 class LoginResponse {
   final UserDto? data;
@@ -40,6 +41,9 @@ class LoginUseCase extends UseCase<AuthState, LoginEvent> {
         }
       }
       return LoginSuccess(login.data, authId: login.authId);
+    } on BaseExceptions catch (e, s) {
+      debugPrintStack(stackTrace: s);
+      return AuthError(e.toString());
     } catch (e, s) {
       debugPrintStack(stackTrace: s);
       return AuthError(e.toString());


### PR DESCRIPTION
## Summary
- Throw `BaseExceptions` when a user's profile is missing after authentication
- Convert repository `BaseExceptions` to `AuthError` in `LoginUseCase`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68ae6cf5d8b8832bbcfa34ce57baa12e