### PR TITLE
Allow admin and reentry org logins on mobile

### DIFF
--- a/lib/domain/usecases/auth/login_usecase.dart
+++ b/lib/domain/usecases/auth/login_usecase.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/foundation.dart';
-import 'package:reentry/data/enum/account_type.dart';
 import 'package:reentry/data/shared/keys.dart';
 import 'package:reentry/data/shared/share_preference.dart';
 import 'package:reentry/di/get_it.dart';
@@ -29,8 +28,8 @@ class LoginUseCase extends UseCase<AuthState, LoginEvent> {
         return AuthError('Something went wrong!');
       }
 
-      if((login.data?.accountType==AccountType.reentry_orgs || login.data?.accountType==AccountType.admin) && kIsWeb==false){
-        return AuthError('Please login with our website');
+      if (login.data?.accountType == null) {
+        return AuthError('Unsupported account type. Please contact support.');
       }
       if (login.data != null) {
         final pref = await locator.getAsync<PersistentStorage>();


### PR DESCRIPTION
## Summary
- permit admin and reentry organization accounts to sign in on mobile
- guard against unknown account types with clearer message

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_b_68ae6cf65734832bbca99983905e73dd