### PR TITLE
Clarify iOS calendar permission usage

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -46,7 +46,7 @@
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSCalendarsUsageDescription</key>
-	<string>INSERT_REASON_HERE</string>
+	<string>We access your calendar to add appointments.</string>
 	<key>NSContactsUsageDescription</key>
 	<string>To select your contact </string>
 	<key>NSPhotoLibraryUsageDescription</key>


### PR DESCRIPTION
## Summary
- update NSCalendarsUsageDescription to inform users that calendar access is used to add appointments

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed, 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68ae6cf6ee80832ba0c9c7387b697475