### PR TITLE
Remove duplicate ProfileCubit provider

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -142,7 +142,6 @@ class _MyAppState extends State<MyApp> {
           BlocProvider(create: (context) => AccountCubit()),
           BlocProvider(create: (context) => OrganizationMembersCubit()),
           BlocProvider(create: (context) => ProfileCubit()),
-          BlocProvider(create: (context) => ProfileCubit()),
           BlocProvider(create: (context) => VerificationQuestionBloc()),
           BlocProvider(create: (context) => VerificationQuestionCubit()),
           BlocProvider(create: (context) => VerificationRequestCubit()),


### PR DESCRIPTION
## Summary
- remove duplicate ProfileCubit registration in MultiBlocProvider

## Testing
- `dart format lib/main.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68ae6cf81518832bbf3e2c5f70471f7c