### PR TITLE
Add auth repository tests for login and OAuth flows

### DIFF
--- a/lib/core/config/supabase_config.dart
+++ b/lib/core/config/supabase_config.dart
@@ -2,6 +2,14 @@ import 'package:flutter/foundation.dart';
 import 'package:supabase_flutter/supabase_flutter.dart' as supabase;
 
 class SupabaseConfig {
+  /// Allow tests to override the [SupabaseClient].
+  static supabase.SupabaseClient? _overrideClient;
+
+  /// Set a mock [SupabaseClient] for testing. Pass `null` to remove override.
+  static set testClient(supabase.SupabaseClient? client) {
+    _overrideClient = client;
+  }
+
   // Supabase project configuration
   static const String supabaseUrl = 'https://ybpohdpizkbysfrvygxx.supabase.co';
   static const String supabaseAnonKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InlicG9oZHBpemtieXNmcnZ5Z3h4Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDk0OTI5MDIsImV4cCI6MjA2NTA2ODkwMn0.74rMWaXYhMkVfcsmopnbHv1N8D-Zoo7PvoshzI0lw_w';
@@ -26,10 +34,10 @@ class SupabaseConfig {
       anonKey: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InlicG9oZHBpemtieXNmcnZ5Z3h4Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDk0OTI5MDIsImV4cCI6MjA2NTA2ODkwMn0.74rMWaXYhMkVfcsmopnbHv1N8D-Zoo7PvoshzI0lw_w',
     );
   }
-  
+
   // Get Supabase client
   static supabase.SupabaseClient get client {
-    return supabase.Supabase.instance.client;
+    return _overrideClient ?? supabase.Supabase.instance.client;
   }
   
   // Check if user is authenticated

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -51,6 +51,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^4.0.0
+  mocktail: ^1.0.1
 
 flutter:
   uses-material-design: true

--- a/test/auth_repository_test.dart
+++ b/test/auth_repository_test.dart
@@ -1,0 +1,147 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:supabase_flutter/supabase_flutter.dart' as supabase;
+
+import 'package:reentry/data/model/user_dto.dart';
+import 'package:reentry/data/enum/account_type.dart';
+import 'package:reentry/data/repository/auth/auth_repository.dart';
+import 'package:reentry/core/config/supabase_config.dart';
+import 'package:reentry/exception/app_exceptions.dart';
+
+// Mocks
+class MockSupabaseClient extends Mock implements supabase.SupabaseClient {}
+
+class MockGoTrueClient extends Mock implements supabase.GoTrueClient {}
+
+class MockAuthResponse extends Mock implements supabase.AuthResponse {}
+
+// Test repository that bypasses network calls for fetching profile
+class _TestAuthRepository extends AuthRepository {
+  final UserDto? _user;
+  _TestAuthRepository(this._user);
+
+  @override
+  Future<UserDto?> findUserById(String id) async => _user;
+}
+
+void main() {
+  late MockSupabaseClient mockClient;
+  late MockGoTrueClient mockAuth;
+
+  setUp(() {
+    mockClient = MockSupabaseClient();
+    mockAuth = MockGoTrueClient();
+    SupabaseConfig.testClient = mockClient;
+    when(() => mockClient.auth).thenReturn(mockAuth);
+  });
+
+  tearDown(() {
+    SupabaseConfig.testClient = null;
+  });
+
+  group('AuthRepository.login', () {
+    final userJson = {
+      'id': 'user-1',
+      'app_metadata': <String, dynamic>{},
+      'user_metadata': <String, dynamic>{},
+      'aud': 'authenticated',
+      'created_at': '2024-01-01T00:00:00Z',
+      'email': 'test@example.com',
+      'phone': '',
+      'confirmed_at': null,
+      'email_confirmed_at': null,
+      'phone_confirmed_at': null,
+      'last_sign_in_at': '2024-01-01T00:00:00Z',
+      'role': 'authenticated',
+      'updated_at': '2024-01-01T00:00:00Z',
+    };
+    final supabaseUser = supabase.User.fromJson(userJson);
+
+    test('returns user profile on successful login', () async {
+      final response = MockAuthResponse();
+      when(() => response.user).thenReturn(supabaseUser);
+      when(() => mockAuth.signInWithPassword(
+            email: any(named: 'email'),
+            password: any(named: 'password'),
+          )).thenAnswer((_) async => response);
+
+      final userDto = UserDto(
+        userId: 'user-1',
+        name: 'Test User',
+        accountType: AccountType.citizen,
+      );
+      final repo = _TestAuthRepository(userDto);
+
+      final result = await repo.login(email: 'test@example.com', password: 'pw');
+
+      expect(result, isNotNull);
+      expect(result?.authId, 'user-1');
+      expect(result?.data, userDto);
+    });
+
+    test('returns null profile when Supabase has no user data', () async {
+      final response = MockAuthResponse();
+      when(() => response.user).thenReturn(supabaseUser);
+      when(() => mockAuth.signInWithPassword(
+            email: any(named: 'email'),
+            password: any(named: 'password'),
+          )).thenAnswer((_) async => response);
+
+      final repo = _TestAuthRepository(null);
+      final result = await repo.login(email: 'test@example.com', password: 'pw');
+
+      expect(result, isNotNull);
+      expect(result?.authId, 'user-1');
+      expect(result?.data, isNull);
+    });
+  });
+
+  group('OAuth callback', () {
+    final userJson = {
+      'id': 'user-2',
+      'app_metadata': <String, dynamic>{},
+      'user_metadata': <String, dynamic>{},
+      'aud': 'authenticated',
+      'created_at': '2024-01-01T00:00:00Z',
+      'email': 'oauth@example.com',
+      'phone': '',
+      'confirmed_at': null,
+      'email_confirmed_at': null,
+      'phone_confirmed_at': null,
+      'last_sign_in_at': '2024-01-01T00:00:00Z',
+      'role': 'authenticated',
+      'updated_at': '2024-01-01T00:00:00Z',
+    };
+    final supabaseUser = supabase.User.fromJson(userJson);
+
+    test('fetches profile after OAuth sign in', () async {
+      when(() => mockAuth.signInWithOAuth(
+            supabase.OAuthProvider.google,
+            redirectTo: any(named: 'redirectTo'),
+          )).thenAnswer((_) async {});
+      when(() => mockAuth.currentUser).thenReturn(supabaseUser);
+
+      final userDto = UserDto(
+        userId: 'user-2',
+        name: 'OAuth User',
+        accountType: AccountType.citizen,
+      );
+      final repo = _TestAuthRepository(userDto);
+
+      final result = await repo.googleSignIn();
+      expect(result, userDto);
+    });
+
+    test('throws when OAuth callback returns no user', () async {
+      when(() => mockAuth.signInWithOAuth(
+            supabase.OAuthProvider.google,
+            redirectTo: any(named: 'redirectTo'),
+          )).thenAnswer((_) async {});
+      when(() => mockAuth.currentUser).thenReturn(null);
+
+      final repo = _TestAuthRepository(null);
+
+      expect(repo.googleSignIn(), throwsA(isA<BaseExceptions>()));
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- allow overriding Supabase client for tests
- add mocktail dev dependency
- create auth repository tests for login success, missing profile, and OAuth callback

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68ae6cf8de98832b8bcad8b40db60342