### PR TITLE
Add client assignees table and repository integration

### DIFF
--- a/lib/data/model/client_dto.dart
+++ b/lib/data/model/client_dto.dart
@@ -133,7 +133,10 @@ class ClientDto {
       status: status,
       createdAt: createdAt is int ? createdAt : DateTime.now().millisecondsSinceEpoch,
       updatedAt: updatedAt is int ? updatedAt : DateTime.now().millisecondsSinceEpoch,
-      assignees: [], // Will be populated separately from client_assignees table
+      assignees: (json['client_assignees'] as List<dynamic>?)
+              ?.map((e) => e['assignee_id'] as String)
+              .toList() ??
+          [],
       droppedReason: null, // Not in persons table
       clientId: json['person_id'] ?? json['id'],
       email: json['email'],

--- a/lib/data/repository/user/user_repository.dart
+++ b/lib/data/repository/user/user_repository.dart
@@ -323,14 +323,16 @@ class UserRepository extends UserRepositoryInterface {
     }
     
     try {
-      if (currentUser.userId != null) {
+      final clientId = currentUser.personId ?? currentUser.userId;
+      if (clientId != null) {
         final response = await SupabaseConfig.client
-            .from('client_assignees') // You'll need to create this table
+            .from('client_assignees')
             .select('assignee_id')
-            .eq('client_id', currentUser.userId!);
-        
+            .eq('client_id', clientId);
+
         if (response.isNotEmpty) {
-          final assigneeIds = response.map((e) => e['assignee_id'] as String).toList();
+          final assigneeIds =
+              response.map((e) => e['assignee_id'] as String).toList();
           return await getUsersByIds(assigneeIds);
         }
       }

--- a/sql fixes/create_client_assignees_table.sql
+++ b/sql fixes/create_client_assignees_table.sql
@@ -1,0 +1,22 @@
+-- Create client_assignees table linking clients (persons) to assignees (user profiles)
+CREATE TABLE IF NOT EXISTS public.client_assignees (
+    id uuid NOT NULL DEFAULT gen_random_uuid(),
+    client_id uuid NOT NULL REFERENCES public.persons(person_id) ON DELETE CASCADE,
+    assignee_id uuid NOT NULL REFERENCES public.user_profiles(id) ON DELETE CASCADE,
+    created_at timestamptz DEFAULT now(),
+    updated_at timestamptz DEFAULT now(),
+    CONSTRAINT client_assignees_pkey PRIMARY KEY (id),
+    CONSTRAINT client_assignees_unique UNIQUE (client_id, assignee_id)
+);
+
+-- Helpful indexes
+CREATE INDEX IF NOT EXISTS idx_client_assignees_client_id ON public.client_assignees(client_id);
+CREATE INDEX IF NOT EXISTS idx_client_assignees_assignee_id ON public.client_assignees(assignee_id);
+
+-- Trigger to update updated_at column
+CREATE TRIGGER update_client_assignees_updated_at
+    BEFORE UPDATE ON public.client_assignees
+    FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+ALTER TABLE public.client_assignees ENABLE ROW LEVEL SECURITY;
+


### PR DESCRIPTION
## Summary
- add SQL migration for client_assignees linking persons and user_profiles
- load assignee IDs in ClientDto and ClientRepository using client_assignees
- update user repository to read assignees via personId

## Testing
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68b1ceaf9d34832b8b17139f69c2011a