### PR TITLE
Add soft delete support for user accounts

### DIFF
--- a/lib/data/model/user_dto.dart
+++ b/lib/data/model/user_dto.dart
@@ -356,6 +356,7 @@ class UserDto {
     String? phoneNumber,
     String? password,
     String? address,
+    String? reasonForAccountDeletion,
   }) {
     return UserDto(
       userId: userId ?? this.userId,
@@ -391,6 +392,8 @@ class UserDto {
       phoneNumber: phoneNumber ?? this.phoneNumber,
       password: password ?? this.password,
       address: address ?? this.address,
+      reasonForAccountDeletion:
+          reasonForAccountDeletion ?? this.reasonForAccountDeletion,
     );
   }
 
@@ -447,7 +450,7 @@ class UserDto {
       avatar: json['avatar'] ?? json['avatar_url'],
       createdAt: json['created_at'] != null ? DateTime.parse(json['created_at']) : null,
       updatedAt: json['updated_at'] != null ? DateTime.parse(json['updated_at']) : null,
-      deleted: false, // Not in schema
+      deleted: json['deleted'] ?? false,
       verificationStatus: null, // Not in schema
       verification: null, // Not in schema
       intakeForm: null, // Not in schema
@@ -473,7 +476,9 @@ class UserDto {
       password: null,
       settings: const UserSettings(),
       about: null,
-      reasonForAccountDeletion: null,
+      reasonForAccountDeletion:
+          json['reasonForAccountDeletion'] ??
+              json['reason_for_account_deletion'],
       supervisorsEmail: json['supervisors_email'],
       address: json['address'],
     );

--- a/lib/data/repository/auth/auth_repository.dart
+++ b/lib/data/repository/auth/auth_repository.dart
@@ -158,6 +158,7 @@ class AuthRepository extends AuthRepositoryInterface {
           .from(SupabaseConfig.userProfilesTable)
           .select()
           .eq('id', id)
+          .eq('deleted', false)
           .single();
       
       if (response != null) {
@@ -173,6 +174,9 @@ class AuthRepository extends AuthRepositoryInterface {
           'account_type': response['account_type'],
           'organizations': response['organizations'],
           'person_id': response['person_id'],
+          'deleted': response['deleted'],
+          'reason_for_account_deletion':
+              response['reason_for_account_deletion'],
         });
       }
       return null;
@@ -188,6 +192,7 @@ class AuthRepository extends AuthRepositoryInterface {
           .from(SupabaseConfig.userProfilesTable)
           .select()
           .eq('person_id', personId)
+          .eq('deleted', false)
           .single();
       
       if (response != null) {
@@ -203,6 +208,9 @@ class AuthRepository extends AuthRepositoryInterface {
           'account_type': response['account_type'],
           'organizations': response['organizations'],
           'person_id': response['person_id'],
+          'deleted': response['deleted'],
+          'reason_for_account_deletion':
+              response['reason_for_account_deletion'],
         });
       }
       return null;

--- a/lib/data/repository/user/user_repository.dart
+++ b/lib/data/repository/user/user_repository.dart
@@ -23,6 +23,8 @@ class UserRepository extends UserRepositoryInterface {
       await SupabaseConfig.client
           .from(SupabaseConfig.userProfilesTable)
           .update({
+            'deleted': true,
+            'reason_for_account_deletion': reason,
             'updated_at': DateTime.now().toIso8601String(),
           })
           .eq('id', userId);
@@ -38,6 +40,7 @@ class UserRepository extends UserRepositoryInterface {
           .from(SupabaseConfig.userProfilesTable)
           .select()
           .eq('id', id)
+          .eq('deleted', false)
           .single();
       if (response != null) {
         return UserDto.fromJson({
@@ -57,6 +60,9 @@ class UserRepository extends UserRepositoryInterface {
           'services': response['services'],
           'created_at': response['created_at'],
           'updated_at': response['updated_at'],
+          'deleted': response['deleted'],
+          'reason_for_account_deletion':
+              response['reason_for_account_deletion'],
         });
       }
       return null;
@@ -74,7 +80,8 @@ class UserRepository extends UserRepositoryInterface {
       final response = await SupabaseConfig.client
           .from(SupabaseConfig.userProfilesTable)
           .select()
-          .inFilter('id', ids);
+          .inFilter('id', ids)
+          .eq('deleted', false);
       return response.map((user) => UserDto.fromJson({
         'id': user['id'],
         'email': user['email'],
@@ -92,6 +99,9 @@ class UserRepository extends UserRepositoryInterface {
         'services': user['services'],
         'created_at': user['created_at'],
         'updated_at': user['updated_at'],
+        'deleted': user['deleted'],
+        'reason_for_account_deletion':
+            user['reason_for_account_deletion'],
       })).toList();
     } catch (e) {
       print('Error getting users from Supabase: $e');
@@ -106,6 +116,7 @@ class UserRepository extends UserRepositoryInterface {
           .from(SupabaseConfig.userProfilesTable)
           .select()
           .not('account_type', 'in', ['citizen', 'admin'])
+          .eq('deleted', false)
           .order('first_name');
 
       return response.map((user) => UserDto.fromJson({
@@ -125,6 +136,9 @@ class UserRepository extends UserRepositoryInterface {
         'services': user['services'],
         'created_at': user['created_at'],
         'updated_at': user['updated_at'],
+        'deleted': user['deleted'],
+        'reason_for_account_deletion':
+            user['reason_for_account_deletion'],
       })).toList();
     } catch (e) {
       print('Error getting care team members from Supabase: $e');
@@ -139,6 +153,7 @@ class UserRepository extends UserRepositoryInterface {
           .from(SupabaseConfig.userProfilesTable)
           .select()
           .eq('account_type', 'citizen')
+          .eq('deleted', false)
           .order('first_name');
 
       return response.map((user) => UserDto.fromJson({
@@ -158,6 +173,9 @@ class UserRepository extends UserRepositoryInterface {
         'services': user['services'],
         'created_at': user['created_at'],
         'updated_at': user['updated_at'],
+        'deleted': user['deleted'],
+        'reason_for_account_deletion':
+            user['reason_for_account_deletion'],
       })).toList();
     } catch (e) {
       print('Error getting citizens from Supabase: $e');
@@ -172,6 +190,7 @@ class UserRepository extends UserRepositoryInterface {
           .from(SupabaseConfig.userProfilesTable)
           .select()
           .or('first_name.ilike.%$searchTerm%,last_name.ilike.%$searchTerm%,email.ilike.%$searchTerm%')
+          .eq('deleted', false)
           .limit(10);
 
       final response = await query;
@@ -197,6 +216,9 @@ class UserRepository extends UserRepositoryInterface {
               'services': user['services'],
               'created_at': user['created_at'],
               'updated_at': user['updated_at'],
+              'deleted': user['deleted'],
+              'reason_for_account_deletion':
+                  user['reason_for_account_deletion'],
             })).toList();
       }
 
@@ -217,6 +239,9 @@ class UserRepository extends UserRepositoryInterface {
         'services': user['services'],
         'created_at': user['created_at'],
         'updated_at': user['updated_at'],
+        'deleted': user['deleted'],
+        'reason_for_account_deletion':
+            user['reason_for_account_deletion'],
       })).toList();
     } catch (e) {
       print('Error searching users from Supabase: $e');

--- a/sql fixes/add_deleted_fields_migration.sql
+++ b/sql fixes/add_deleted_fields_migration.sql
@@ -1,0 +1,7 @@
+-- Migration to add deleted and reason_for_account_deletion fields to user_profiles table
+ALTER TABLE public.user_profiles
+    ADD COLUMN IF NOT EXISTS deleted BOOLEAN DEFAULT FALSE,
+    ADD COLUMN IF NOT EXISTS reason_for_account_deletion TEXT;
+
+-- Optional index for faster lookups of active users
+CREATE INDEX IF NOT EXISTS idx_user_profiles_deleted ON public.user_profiles (deleted);

--- a/test/auth_repository_test.dart
+++ b/test/auth_repository_test.dart
@@ -79,7 +79,7 @@ void main() {
       expect(result?.data, userDto);
     });
 
-    test('returns null profile when Supabase has no user data', () async {
+    test('throws when user profile is missing or deleted', () async {
       final response = MockAuthResponse();
       when(() => response.user).thenReturn(supabaseUser);
       when(() => mockAuth.signInWithPassword(
@@ -88,11 +88,11 @@ void main() {
           )).thenAnswer((_) async => response);
 
       final repo = _TestAuthRepository(null);
-      final result = await repo.login(email: 'test@example.com', password: 'pw');
 
-      expect(result, isNotNull);
-      expect(result?.authId, 'user-1');
-      expect(result?.data, isNull);
+      expect(
+          () async =>
+              await repo.login(email: 'test@example.com', password: 'pw'),
+          throwsA(isA<BaseExceptions>()));
     });
   });
 

--- a/test/user_repository_test.dart
+++ b/test/user_repository_test.dart
@@ -1,0 +1,61 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:supabase_flutter/supabase_flutter.dart' as supabase;
+
+import 'package:reentry/data/repository/user/user_repository.dart';
+import 'package:reentry/core/config/supabase_config.dart';
+
+class MockSupabaseClient extends Mock implements supabase.SupabaseClient {}
+
+class MockPostgrestFilterBuilder extends Mock
+    implements supabase.PostgrestFilterBuilder {}
+
+void main() {
+  late MockSupabaseClient mockClient;
+  late MockPostgrestFilterBuilder mockBuilder;
+
+  setUp(() {
+    mockClient = MockSupabaseClient();
+    mockBuilder = MockPostgrestFilterBuilder();
+    SupabaseConfig.testClient = mockClient;
+
+    when(() => mockClient.from(any())).thenReturn(mockBuilder);
+    when(() => mockBuilder.select()).thenReturn(mockBuilder);
+    when(() => mockBuilder.eq(any(), any())).thenReturn(mockBuilder);
+    when(() => mockBuilder.order(any())).thenAnswer((_) async => [
+          {
+            'id': '1',
+            'email': 'a@b.com',
+            'first_name': 'John',
+            'last_name': 'Doe',
+            'phone': '',
+            'avatar_url': null,
+            'address': null,
+            'account_type': 'citizen',
+            'organizations': [],
+            'organization': null,
+            'organization_address': null,
+            'job_title': null,
+            'supervisors_name': null,
+            'supervisors_email': null,
+            'services': [],
+            'created_at': null,
+            'updated_at': null,
+            'deleted': false,
+            'reason_for_account_deletion': null,
+          }
+        ]);
+  });
+
+  tearDown(() {
+    SupabaseConfig.testClient = null;
+  });
+
+  test('getCitizens filters out deleted users', () async {
+    final repo = UserRepository();
+    final users = await repo.getCitizens();
+
+    expect(users.length, 1);
+    verify(() => mockBuilder.eq('deleted', false)).called(1);
+  });
+}


### PR DESCRIPTION
## Summary
- add `deleted` and `reason_for_account_deletion` fields to user_profiles schema
- update repositories and models to respect soft-deleted accounts
- add tests ensuring deleted users are filtered out

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68b1ce94ba64832bba497b04e9d6e904