### PR TITLE
Use snake_case for additional user profile fields

### DIFF
--- a/lib/data/model/user_dto.dart
+++ b/lib/data/model/user_dto.dart
@@ -421,13 +421,13 @@ class UserDto {
       'dob': dob,
       'availability': availability?.toJson(),
       'mentors': mentors,
-      'pushNotificationToken': pushNotificationToken,
+      'push_notification_token': pushNotificationToken,
       'userCode': userCode,
       'person_id': personId,
       'officers': officers,
       'password': password,
       'settings': settings.toJson(),
-      'reasonForAccountDeletion': reasonForAccountDeletion,
+      'reason_for_account_deletion': reasonForAccountDeletion,
       'supervisors_email': supervisorsEmail,
       'address': address,
     };
@@ -447,7 +447,7 @@ class UserDto {
       avatar: json['avatar'] ?? json['avatar_url'],
       createdAt: json['created_at'] != null ? DateTime.parse(json['created_at']) : null,
       updatedAt: json['updated_at'] != null ? DateTime.parse(json['updated_at']) : null,
-      deleted: false, // Not in schema
+      deleted: json['deleted'] ?? false,
       verificationStatus: null, // Not in schema
       verification: null, // Not in schema
       intakeForm: null, // Not in schema
@@ -458,7 +458,7 @@ class UserDto {
       jobTitle: json['job_title'],
       organization: json['organization'],
       organizationAddress: json['organization_address'],
-      organizations: json['organizations'] != null 
+      organizations: json['organizations'] != null
           ? List<String>.from(json['organizations'])
           : const [],
       activityDate: null,
@@ -466,14 +466,14 @@ class UserDto {
       dob: json['dob'],
       availability: null,
       mentors: const [],
-      pushNotificationToken: null,
+      pushNotificationToken: json['push_notification_token'],
       userCode: json['userCode'],
       personId: json['person_id'],
       officers: const [],
       password: null,
-      settings: const UserSettings(),
+      settings: json['settings'] != null ? UserSettings.fromJson(json['settings']) : const UserSettings(),
       about: null,
-      reasonForAccountDeletion: null,
+      reasonForAccountDeletion: json['reason_for_account_deletion'],
       supervisorsEmail: json['supervisors_email'],
       address: json['address'],
     );
@@ -541,9 +541,9 @@ class UserSettings {
 
   Map<String, dynamic> toJson() {
     return {
-      'pushNotification': pushNotification,
-      'emailNotification': emailNotification,
-      'smsNotification': smsNotification,
+      'push_notification': pushNotification,
+      'email_notification': emailNotification,
+      'sms_notification': smsNotification,
       'language': language,
       'theme': theme,
     };
@@ -551,9 +551,9 @@ class UserSettings {
 
   factory UserSettings.fromJson(Map<String, dynamic> json) {
     return UserSettings(
-      pushNotification: json['pushNotification'] ?? true,
-      emailNotification: json['emailNotification'] ?? true,
-      smsNotification: json['smsNotification'] ?? false,
+      pushNotification: json['push_notification'] ?? true,
+      emailNotification: json['email_notification'] ?? true,
+      smsNotification: json['sms_notification'] ?? false,
       language: json['language'],
       theme: json['theme'],
     );

--- a/lib/data/repository/auth/auth_repository.dart
+++ b/lib/data/repository/auth/auth_repository.dart
@@ -173,6 +173,10 @@ class AuthRepository extends AuthRepositoryInterface {
           'account_type': response['account_type'],
           'organizations': response['organizations'],
           'person_id': response['person_id'],
+          'deleted': response['deleted'],
+          'push_notification_token': response['push_notification_token'],
+          'reason_for_account_deletion': response['reason_for_account_deletion'],
+          'settings': response['settings'],
         });
       }
       return null;
@@ -203,6 +207,10 @@ class AuthRepository extends AuthRepositoryInterface {
           'account_type': response['account_type'],
           'organizations': response['organizations'],
           'person_id': response['person_id'],
+          'deleted': response['deleted'],
+          'push_notification_token': response['push_notification_token'],
+          'reason_for_account_deletion': response['reason_for_account_deletion'],
+          'settings': response['settings'],
         });
       }
       return null;
@@ -299,6 +307,10 @@ class AuthRepository extends AuthRepositoryInterface {
             'address': payload.address,
             'account_type': payload.accountType.name,
             'organizations': payload.organizations,
+            'push_notification_token': payload.pushNotificationToken,
+            'reason_for_account_deletion': payload.reasonForAccountDeletion,
+            'deleted': payload.deleted,
+            'settings': payload.settings.toJson(),
             'updated_at': DateTime.now().toIso8601String(),
           })
           .eq('id', payload.userId!);

--- a/lib/data/repository/user/user_repository.dart
+++ b/lib/data/repository/user/user_repository.dart
@@ -57,6 +57,10 @@ class UserRepository extends UserRepositoryInterface {
           'services': response['services'],
           'created_at': response['created_at'],
           'updated_at': response['updated_at'],
+          'deleted': response['deleted'],
+          'push_notification_token': response['push_notification_token'],
+          'reason_for_account_deletion': response['reason_for_account_deletion'],
+          'settings': response['settings'],
         });
       }
       return null;
@@ -92,6 +96,10 @@ class UserRepository extends UserRepositoryInterface {
         'services': user['services'],
         'created_at': user['created_at'],
         'updated_at': user['updated_at'],
+        'deleted': user['deleted'],
+        'push_notification_token': user['push_notification_token'],
+        'reason_for_account_deletion': user['reason_for_account_deletion'],
+        'settings': user['settings'],
       })).toList();
     } catch (e) {
       print('Error getting users from Supabase: $e');
@@ -125,6 +133,10 @@ class UserRepository extends UserRepositoryInterface {
         'services': user['services'],
         'created_at': user['created_at'],
         'updated_at': user['updated_at'],
+        'deleted': user['deleted'],
+        'push_notification_token': user['push_notification_token'],
+        'reason_for_account_deletion': user['reason_for_account_deletion'],
+        'settings': user['settings'],
       })).toList();
     } catch (e) {
       print('Error getting care team members from Supabase: $e');
@@ -158,6 +170,10 @@ class UserRepository extends UserRepositoryInterface {
         'services': user['services'],
         'created_at': user['created_at'],
         'updated_at': user['updated_at'],
+        'deleted': user['deleted'],
+        'push_notification_token': user['push_notification_token'],
+        'reason_for_account_deletion': user['reason_for_account_deletion'],
+        'settings': user['settings'],
       })).toList();
     } catch (e) {
       print('Error getting citizens from Supabase: $e');
@@ -197,6 +213,10 @@ class UserRepository extends UserRepositoryInterface {
               'services': user['services'],
               'created_at': user['created_at'],
               'updated_at': user['updated_at'],
+              'deleted': user['deleted'],
+              'push_notification_token': user['push_notification_token'],
+              'reason_for_account_deletion': user['reason_for_account_deletion'],
+              'settings': user['settings'],
             })).toList();
       }
 
@@ -217,6 +237,10 @@ class UserRepository extends UserRepositoryInterface {
         'services': user['services'],
         'created_at': user['created_at'],
         'updated_at': user['updated_at'],
+        'deleted': user['deleted'],
+        'push_notification_token': user['push_notification_token'],
+        'reason_for_account_deletion': user['reason_for_account_deletion'],
+        'settings': user['settings'],
       })).toList();
     } catch (e) {
       print('Error searching users from Supabase: $e');
@@ -269,6 +293,10 @@ class UserRepository extends UserRepositoryInterface {
             'supervisors_name': payload.supervisorsName,
             'supervisors_email': payload.supervisorsEmail,
             'services': payload.services,
+            'push_notification_token': payload.pushNotificationToken,
+            'reason_for_account_deletion': payload.reasonForAccountDeletion,
+            'deleted': payload.deleted,
+            'settings': payload.settings.toJson(),
             'updated_at': DateTime.now().toIso8601String(),
       };
       

--- a/test/user_dto_test.dart
+++ b/test/user_dto_test.dart
@@ -1,0 +1,46 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reentry/data/model/user_dto.dart';
+import 'package:reentry/data/enum/account_type.dart';
+
+void main() {
+  test('UserDto parses and serializes snake_case fields', () {
+    final json = {
+      'id': '1',
+      'name': 'Test User',
+      'account_type': 'citizen',
+      'deleted': true,
+      'push_notification_token': 'token',
+      'reason_for_account_deletion': 'reason',
+      'settings': {
+        'push_notification': false,
+        'email_notification': true,
+        'sms_notification': true,
+        'language': 'en',
+        'theme': 'dark',
+      }
+    };
+
+    final user = UserDto.fromJson(json);
+    expect(user.deleted, isTrue);
+    expect(user.accountType, AccountType.citizen);
+    expect(user.pushNotificationToken, 'token');
+    expect(user.reasonForAccountDeletion, 'reason');
+    expect(user.settings.pushNotification, isFalse);
+    expect(user.settings.emailNotification, isTrue);
+    expect(user.settings.smsNotification, isTrue);
+    expect(user.settings.language, 'en');
+    expect(user.settings.theme, 'dark');
+
+    final serialized = user.toJson();
+    expect(serialized['deleted'], isTrue);
+    expect(serialized['push_notification_token'], 'token');
+    expect(serialized['reason_for_account_deletion'], 'reason');
+    expect(serialized['settings'], {
+      'push_notification': false,
+      'email_notification': true,
+      'sms_notification': true,
+      'language': 'en',
+      'theme': 'dark',
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- parse & serialize deleted, push_notification_token, reason_for_account_deletion, and settings using snake_case keys
- update auth and user repositories to read/write the new profile fields
- add a unit test ensuring UserDto preserves these snake_case fields

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68b1ceb6b498832bbc7f10b6c3aa5ca8