### PR TITLE
Store person ID when creating account

### DIFF
--- a/lib/data/repository/auth/auth_repository.dart
+++ b/lib/data/repository/auth/auth_repository.dart
@@ -112,8 +112,10 @@ class AuthRepository extends AuthRepositoryInterface {
             'created_at': DateTime.now().toIso8601String(),
             'updated_at': DateTime.now().toIso8601String(),
           })
-          .select()
+          .select('person_id')
           .single();
+
+      final personId = personResponse['person_id'];
       
       // Then create user profile with the person_id
       final response = await SupabaseConfig.client
@@ -125,7 +127,7 @@ class AuthRepository extends AuthRepositoryInterface {
             'last_name': createAccount.name?.split(' ').skip(1).join(' '),
             'phone': createAccount.phoneNumber,
             'address': createAccount.address,
-            'person_id': personResponse['person_id'],
+            'person_id': personId,
             'account_type': createAccount.accountType.name,
             'organizations': organizations,
             'organization': createAccount.organization,
@@ -146,6 +148,7 @@ class AuthRepository extends AuthRepositoryInterface {
         userCode: DateTime.now().millisecondsSinceEpoch.toString(),
         updatedAt: DateTime.now(),
         organizations: organizations,
+        personId: personId,
       );
     } catch (e) {
       throw BaseExceptions('Failed to create account in Supabase: ${e.toString()}');


### PR DESCRIPTION
## Summary
- Select `person_id` after inserting into `persons` and reuse it when creating the user profile
- Return the `person_id` in the created account data

## Testing
- `psql --version` *(fails: command not found)*
- `apt-get update` *(fails: repository access 403)*
- `flutter test` *(fails: command not found)*
- `curl -X POST https://ybpohdpizkbysfrvygxx.supabase.co/sql/v1` *(fails: 403 Forbidden)*
- `curl -X POST https://ybpohdpizkbysfrvygxx.supabase.co/auth/v1/signup` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68b1ce70d06c832b8c13d94b1f671591