### PR TITLE
Parse user profile settings and deletion data

### DIFF
--- a/lib/data/model/user_dto.dart
+++ b/lib/data/model/user_dto.dart
@@ -421,13 +421,13 @@ class UserDto {
       'dob': dob,
       'availability': availability?.toJson(),
       'mentors': mentors,
-      'pushNotificationToken': pushNotificationToken,
+      'push_notification_token': pushNotificationToken,
       'userCode': userCode,
       'person_id': personId,
       'officers': officers,
       'password': password,
       'settings': settings.toJson(),
-      'reasonForAccountDeletion': reasonForAccountDeletion,
+      'reason_for_account_deletion': reasonForAccountDeletion,
       'supervisors_email': supervisorsEmail,
       'address': address,
     };
@@ -447,7 +447,7 @@ class UserDto {
       avatar: json['avatar'] ?? json['avatar_url'],
       createdAt: json['created_at'] != null ? DateTime.parse(json['created_at']) : null,
       updatedAt: json['updated_at'] != null ? DateTime.parse(json['updated_at']) : null,
-      deleted: false, // Not in schema
+      deleted: json['deleted'] ?? false,
       verificationStatus: null, // Not in schema
       verification: null, // Not in schema
       intakeForm: null, // Not in schema
@@ -458,7 +458,7 @@ class UserDto {
       jobTitle: json['job_title'],
       organization: json['organization'],
       organizationAddress: json['organization_address'],
-      organizations: json['organizations'] != null 
+      organizations: json['organizations'] != null
           ? List<String>.from(json['organizations'])
           : const [],
       activityDate: null,
@@ -466,14 +466,16 @@ class UserDto {
       dob: json['dob'],
       availability: null,
       mentors: const [],
-      pushNotificationToken: null,
+      pushNotificationToken: json['push_notification_token'],
       userCode: json['userCode'],
       personId: json['person_id'],
       officers: const [],
       password: null,
-      settings: const UserSettings(),
+      settings: json['settings'] != null
+          ? UserSettings.fromJson(Map<String, dynamic>.from(json['settings']))
+          : const UserSettings(),
       about: null,
-      reasonForAccountDeletion: null,
+      reasonForAccountDeletion: json['reason_for_account_deletion'],
       supervisorsEmail: json['supervisors_email'],
       address: json['address'],
     );

--- a/lib/data/repository/user/user_repository.dart
+++ b/lib/data/repository/user/user_repository.dart
@@ -269,6 +269,10 @@ class UserRepository extends UserRepositoryInterface {
             'supervisors_name': payload.supervisorsName,
             'supervisors_email': payload.supervisorsEmail,
             'services': payload.services,
+            'push_notification_token': payload.pushNotificationToken,
+            'settings': payload.settings.toJson(),
+            'deleted': payload.deleted,
+            'reason_for_account_deletion': payload.reasonForAccountDeletion,
             'updated_at': DateTime.now().toIso8601String(),
       };
       

--- a/sql fixes/add_user_profile_settings_columns.sql
+++ b/sql fixes/add_user_profile_settings_columns.sql
@@ -1,0 +1,5 @@
+-- Migration to add settings and notification fields to user_profiles table
+ALTER TABLE public.user_profiles ADD COLUMN IF NOT EXISTS push_notification_token text;
+ALTER TABLE public.user_profiles ADD COLUMN IF NOT EXISTS settings jsonb DEFAULT '{}'::jsonb;
+ALTER TABLE public.user_profiles ADD COLUMN IF NOT EXISTS deleted boolean DEFAULT false;
+ALTER TABLE public.user_profiles ADD COLUMN IF NOT EXISTS reason_for_account_deletion text;


### PR DESCRIPTION
## Summary
- parse `push_notification_token`, `settings`, `deleted`, and `reason_for_account_deletion` in `UserDto`
- send new fields when updating user profile data
- add SQL migration to add matching columns in `user_profiles`

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_b_68b1cdb009f8832bbd78b00ead0c9880