### PR TITLE
Fetch person ID after user profile creation

### DIFF
--- a/lib/data/repository/auth/auth_repository.dart
+++ b/lib/data/repository/auth/auth_repository.dart
@@ -112,7 +112,7 @@ class AuthRepository extends AuthRepositoryInterface {
             'created_at': DateTime.now().toIso8601String(),
             'updated_at': DateTime.now().toIso8601String(),
           })
-          .select()
+          .select('person_id')
           .single();
       
       // Then create user profile with the person_id
@@ -137,15 +137,16 @@ class AuthRepository extends AuthRepositoryInterface {
             'created_at': DateTime.now().toIso8601String(),
             'updated_at': DateTime.now().toIso8601String(),
           })
-          .select()
+          .select('id, person_id')
           .single();
-      
+
       return createAccount.copyWith(
         userId: response['id'],
         createdAt: DateTime.now(),
         userCode: DateTime.now().millisecondsSinceEpoch.toString(),
         updatedAt: DateTime.now(),
         organizations: organizations,
+        personId: response['person_id'],
       );
     } catch (e) {
       throw BaseExceptions('Failed to create account in Supabase: ${e.toString()}');


### PR DESCRIPTION
## Summary
- Retrieve newly created `person_id` when inserting a user profile and surface it in returned UserDto

## Testing
- `dart format lib/data/repository/auth/auth_repository.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `psql "..." -f 'sql fixes/fix_user_creation_migration.sql'` *(fails: command not found)*
- `curl -X POST "$PROJECT_URL/auth/v1/signup" ...` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_b_68b1cd595ce0832ba3f086f5e5e88716