### PR TITLE
feat: introduce Kotlin multiplatform shared module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ app.*.map.json
 
 # FVM Version Cache
 .fvm/
+
+# Kotlin Multiplatform build output
+/shared/build/

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -42,3 +42,7 @@ android {
 flutter {
     source = "../.."
 }
+
+dependencies {
+    implementation project(":shared")
+}

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -23,3 +23,5 @@ plugins {
 }
 
 include ":app"
+include ":shared"
+project(":shared").projectDir = new File(rootDir, "../shared")

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -32,6 +32,7 @@ target 'Runner' do
   use_modular_headers!
 
   flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
+  pod 'shared', :path => '../shared'
   target 'RunnerTests' do
     inherit! :search_paths
   end

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -1,0 +1,48 @@
+plugins {
+    kotlin("multiplatform")
+    id("com.android.library")
+    kotlin("native.cocoapods")
+}
+
+kotlin {
+    android()
+    iosX64()
+    iosArm64()
+    iosSimulatorArm64()
+
+    cocoapods {
+        summary = "Shared domain and data models"
+        homepage = "https://example.com"
+        ios.deploymentTarget = "13.0"
+        framework {
+            baseName = "shared"
+        }
+    }
+
+    sourceSets {
+        val commonMain by getting {
+            dependencies {
+                // Common dependencies can be added here
+            }
+        }
+        val commonTest by getting
+        val androidMain by getting
+        val iosX64Main by getting
+        val iosArm64Main by getting
+        val iosSimulatorArm64Main by getting
+        val iosMain by creating {
+            dependsOn(commonMain)
+            iosX64Main.dependsOn(this)
+            iosArm64Main.dependsOn(this)
+            iosSimulatorArm64Main.dependsOn(this)
+        }
+    }
+}
+
+android {
+    namespace = "com.reentry.shared"
+    compileSdk = 33
+    defaultConfig {
+        minSdk = 21
+    }
+}

--- a/shared/src/androidMain/kotlin/com/reentry/shared/Platform.kt
+++ b/shared/src/androidMain/kotlin/com/reentry/shared/Platform.kt
@@ -1,0 +1,3 @@
+package com.reentry.shared
+
+actual fun platformName(): String = "Android"

--- a/shared/src/commonMain/kotlin/com/reentry/shared/Mood.kt
+++ b/shared/src/commonMain/kotlin/com/reentry/shared/Mood.kt
@@ -1,0 +1,21 @@
+package com.reentry.shared
+
+data class Mood(
+    val id: String,
+    val name: String,
+    val icon: String? = null,
+    val category: String? = null
+)
+
+data class MoodLog(
+    val id: String,
+    val userId: String,
+    val mood: Mood,
+    val notes: String? = null,
+    val intensity: Int? = null,
+    val createdAt: String
+)
+
+fun formatMoodLog(log: MoodLog): String {
+    return "${'$'}{log.mood.name} at ${'$'}{log.createdAt}"
+}

--- a/shared/src/commonMain/kotlin/com/reentry/shared/Platform.kt
+++ b/shared/src/commonMain/kotlin/com/reentry/shared/Platform.kt
@@ -1,0 +1,3 @@
+package com.reentry.shared
+
+expect fun platformName(): String

--- a/shared/src/iosMain/kotlin/com/reentry/shared/Platform.kt
+++ b/shared/src/iosMain/kotlin/com/reentry/shared/Platform.kt
@@ -1,0 +1,3 @@
+package com.reentry.shared
+
+actual fun platformName(): String = "iOS"


### PR DESCRIPTION
## Summary
- add Kotlin Multiplatform library containing shared domain models
- wire Android and iOS builds to compile and link the shared module
- ignore generated build output from the shared library

## Testing
- ❌ `flutter analyze` *(command not found)*
- ⚠️ `apt-get update` *(repository not signed)*
- ❌ `./android/gradlew -p android :app:assembleDebug` *(file not found)*

------
https://chatgpt.com/codex/tasks/task_b_68b7c97d7488832bad658065ed367873