### PR TITLE
Add platform-specific CI and feature flag infrastructure

### DIFF
--- a/.github/workflows/android_ci.yml
+++ b/.github/workflows/android_ci.yml
@@ -1,0 +1,23 @@
+name: Android CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+      - run: flutter pub get
+      - name: Run unit tests
+        run: flutter test
+      - name: Run integration tests
+        run: |
+          if [ -d "integration_test" ]; then
+            flutter test integration_test
+          fi

--- a/.github/workflows/ios_ci.yml
+++ b/.github/workflows/ios_ci.yml
@@ -1,0 +1,23 @@
+name: iOS CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+      - run: flutter pub get
+      - name: Run unit tests
+        run: flutter test
+      - name: Run integration tests
+        run: |
+          if [ -d "integration_test" ]; then
+            flutter test integration_test
+          fi

--- a/README.md
+++ b/README.md
@@ -14,3 +14,9 @@ A few resources to get you started if this is your first Flutter project:
 For help getting started with Flutter development, view the
 [online documentation](https://docs.flutter.dev/), which offers tutorials,
 samples, guidance on mobile development, and a full API reference.
+
+## CI and Monitoring
+
+- GitHub Actions run separate Android and iOS pipelines to execute unit and UI tests.
+- A simple `FeatureFlags` utility enables phased rollouts so early adopters can try new features.
+- `MonitoringService` provides hooks for analytics and crash reporting to ensure parity with the original Flutter release.

--- a/lib/core/config/feature_flags.dart
+++ b/lib/core/config/feature_flags.dart
@@ -1,0 +1,23 @@
+import 'package:reentry/data/shared/keys.dart';
+import 'package:reentry/data/shared/share_preference.dart';
+
+/// Simple feature flag storage backed by [PersistentStorage].
+///
+/// Flags are stored under the [Keys.features] key so that
+/// experimental functionality can be toggled for phased rollouts.
+class FeatureFlags {
+  final PersistentStorage _storage;
+
+  FeatureFlags(this._storage);
+
+  Map<String, dynamic> _flags() =>
+      _storage.getDataFromCache(Keys.features) ?? <String, dynamic>{};
+
+  bool isEnabled(String name) => _flags()[name] == true;
+
+  Future<void> setFlag(String name, bool enabled) async {
+    final flags = _flags();
+    flags[name] = enabled;
+    await _storage.cacheData(data: flags, key: Keys.features);
+  }
+}

--- a/lib/core/monitoring/monitoring_service.dart
+++ b/lib/core/monitoring/monitoring_service.dart
@@ -1,0 +1,16 @@
+import 'dart:developer' as developer;
+
+/// Basic analytics and crash reporting helper.
+///
+/// This class can be wired to services like Firebase Analytics or Sentry
+/// to collect metrics and error reports ensuring parity with the original
+/// Flutter implementation.
+class MonitoringService {
+  void logEvent(String name, [Map<String, Object?>? parameters]) {
+    developer.log('event: ' + name, name: 'analytics', error: parameters);
+  }
+
+  void reportError(Object error, StackTrace stackTrace) {
+    developer.log('error: ' + error.toString(), name: 'crash', error: stackTrace);
+  }
+}

--- a/lib/di/get_it.dart
+++ b/lib/di/get_it.dart
@@ -22,6 +22,8 @@ import '../data/repository/messaging/messaging_repository_interface.dart';
 import '../data/repository/mentor/mentor_repository.dart';
 import '../data/repository/mentor/mentor_repository_interface.dart';
 import '../core/config/app_config.dart';
+import '../core/config/feature_flags.dart';
+import '../core/monitoring/monitoring_service.dart';
 
 GetIt locator = GetIt.instance;
 
@@ -40,4 +42,9 @@ void setupDi(){
   locator.registerLazySingleton<ReportRepositoryInterface>(() => ReportRepository());
   locator.registerLazySingleton<MessagingRepositoryInterface>(() => MessageRepository());
   locator.registerLazySingleton<MentorRepositoryInterface>(() => MentorRepository());
+  locator.registerLazySingletonAsync<FeatureFlags>(() async {
+    final storage = await locator.getAsync<PersistentStorage>();
+    return FeatureFlags(storage);
+  });
+  locator.registerLazySingleton<MonitoringService>(() => MonitoringService());
 }


### PR DESCRIPTION
## Summary
- add separate Android and iOS GitHub Actions workflows to run unit and integration tests
- introduce FeatureFlags utility for phased rollouts
- add MonitoringService for analytics and crash reporting hooks
- register new services in dependency injection

## Testing
- `flutter test` *(fails: command not found)*
- `git clone https://github.com/flutter/flutter.git -b stable /tmp/flutter` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_b_68b7c97cd040832bb87dda194f615e64